### PR TITLE
Add Amplitude tracking across the ZICKONEZERO site

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,70 @@
+import { trackEvent, trackLinkClick, trackPageView } from '../src/lib/analytics';
+
+type TestWindow = Window & {
+  amplitude?: {
+    track?: jest.Mock;
+    logEvent?: jest.Mock;
+  };
+};
+
+describe('analytics helpers', () => {
+  beforeEach(() => {
+    delete (window as TestWindow).amplitude;
+    document.title = 'Test page';
+  });
+
+  it('tracks custom events with Amplitude track', () => {
+    const track = jest.fn();
+    (window as TestWindow).amplitude = { track };
+
+    trackEvent('cta_click', { label: 'Start' });
+
+    expect(track).toHaveBeenCalledWith('cta_click', { label: 'Start' });
+  });
+
+  it('falls back to Amplitude logEvent when track is unavailable', () => {
+    const logEvent = jest.fn();
+    (window as TestWindow).amplitude = { logEvent };
+
+    trackEvent('cta_click', { label: 'Start' });
+
+    expect(logEvent).toHaveBeenCalledWith('cta_click', { label: 'Start' });
+  });
+
+  it('tracks normalized link click payloads', () => {
+    const track = jest.fn();
+    (window as TestWindow).amplitude = { track };
+
+    trackLinkClick({
+      location: 'footer',
+      label: 'GitHub',
+      href: 'https://github.com/michaelzick',
+      section: 'links',
+      variant: 'desktop',
+    });
+
+    expect(track).toHaveBeenCalledWith('link_click', {
+      link_location: 'footer',
+      link_text: 'GitHub',
+      link_url: 'https://github.com/michaelzick',
+      link_external: true,
+      link_section: 'links',
+      link_variant: 'desktop',
+      page_path: '/',
+    });
+  });
+
+  it('tracks page views with URL metadata', () => {
+    const track = jest.fn();
+    (window as TestWindow).amplitude = { track };
+
+    trackPageView('/about?source=test', 'About');
+
+    expect(track).toHaveBeenCalledWith('page_view', {
+      page_path: '/about',
+      page_url: 'http://localhost/about?source=test',
+      page_title: 'About',
+      page_referrer: undefined,
+    });
+  });
+});

--- a/__tests__/project-showcase.test.tsx
+++ b/__tests__/project-showcase.test.tsx
@@ -20,6 +20,10 @@ jest.mock('fslightbox-react', () => function MockFsLightbox(props: {
 });
 
 describe('ProjectShowcase', () => {
+  beforeEach(() => {
+    delete (window as Window & { amplitude?: unknown }).amplitude;
+  });
+
   it('renders section screenshots as real lightbox buttons', () => {
     renderWithProviders(
       <ProjectShowcase
@@ -93,5 +97,38 @@ describe('ProjectShowcase', () => {
 
     expect(lightbox).toHaveAttribute('data-slide', '2');
     expect(lightbox).toHaveAttribute('data-toggler', 'true');
+  });
+
+  it('tracks showcase lightbox opens', async () => {
+    const user = userEvent.setup();
+    const track = jest.fn();
+    (window as Window & { amplitude?: { track: jest.Mock } }).amplitude = { track };
+
+    renderWithProviders(
+      <ProjectShowcase
+        title='Test Showcase'
+        summary='A focused test fixture.'
+        heroImage={{ src: '/img/projects/fyfs/fyfs-wave.webp', alt: 'Hero image' }}
+        roleBullets={['UX design']}
+        projectLink={{ href: 'https://example.com', label: 'example.com' }}
+        sections={[
+          {
+            title: 'First section',
+            body: <>First section body</>,
+            image: { src: '/img/projects/fyfs/fyfs-home.webp', alt: 'First mock screenshot' }
+          }
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open image: First mock screenshot' }));
+
+    expect(track).toHaveBeenCalledWith('lightbox_open', expect.objectContaining({
+      location: 'project_showcase',
+      project_title: 'Test Showcase',
+      section_title: 'First section',
+      image_alt: 'First mock screenshot',
+      image_index: 0,
+    }));
   });
 });

--- a/__tests__/tracked-link.test.tsx
+++ b/__tests__/tracked-link.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TrackedLink from '../src/components/TrackedLink';
+
+type TestWindow = Window & {
+  amplitude?: {
+    track?: jest.Mock;
+  };
+};
+
+describe('TrackedLink', () => {
+  beforeEach(() => {
+    delete (window as TestWindow).amplitude;
+  });
+
+  it('renders internal links with Next link semantics', () => {
+    render(
+      <TrackedLink href='/about' label='About' location='test'>
+        About
+      </TrackedLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute('href', '/about');
+  });
+
+  it('preserves external target and rel while tracking clicks', async () => {
+    const user = userEvent.setup();
+    const track = jest.fn();
+    (window as TestWindow).amplitude = { track };
+
+    render(
+      <TrackedLink
+        href='https://github.com/michaelzick'
+        label='GitHub'
+        location='test'
+        target='_blank'
+      >
+        GitHub
+      </TrackedLink>
+    );
+
+    const link = screen.getByRole('link', { name: 'GitHub' });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+
+    await user.click(link);
+
+    expect(track).toHaveBeenCalledWith('link_click', expect.objectContaining({
+      link_location: 'test',
+      link_text: 'GitHub',
+      link_url: 'https://github.com/michaelzick',
+      link_external: true,
+    }));
+  });
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,8 @@ import { Provider } from 'react-redux';
 import { store } from '../src/store';
 
 import { HeadContent } from '../src/components';
+import PageAnalytics from '../src/components/PageAnalytics';
+import SiteAnalyticsScripts from '../src/components/SiteAnalyticsScripts';
 import { AppThemeProvider } from '../src/theme/ThemeContext';
 import { Container } from '../styles';
 
@@ -30,6 +32,8 @@ function MyApp({
               `,
             }}
           />
+          <SiteAnalyticsScripts />
+          <PageAnalytics />
 
           <Head>
             <meta name="viewport" content="width=device-width, initial-scale=1"></meta>

--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -9,8 +9,6 @@ import {
   getMobileMenuState
 } from '../showMobileMenuSlice';
 
-import Link from 'next/link';
-
 import {
   DemoStokeMiniCardModal,
   DemoStokeMiniCardModalClose,
@@ -22,6 +20,8 @@ import {
 import { AnimatedSection } from '../../styles/projectShowcases';
 import { THEME } from '../../styles/theme';
 import { TopNavContent, FooterContent } from '../components';
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
 
 const AboutHero = styled.section`
   position: relative;
@@ -136,10 +136,22 @@ const AboutContent = () => {
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
 
   const openAboutModal = useCallback(() => {
+    trackEvent('modal_open', {
+      location: 'about_hero',
+      label: 'About Michael',
+      modal: 'about_michael',
+      page_path: window.location.pathname,
+    });
     setIsAboutModalOpen(true);
   }, []);
 
   const closeAboutModal = useCallback(() => {
+    trackEvent('modal_close', {
+      location: 'about_modal',
+      label: 'About Michael',
+      modal: 'about_michael',
+      page_path: window.location.pathname,
+    });
     setIsAboutModalOpen(false);
   }, []);
 
@@ -225,10 +237,12 @@ const AboutContent = () => {
                   From concept to launch, Michael thrives on solving complex problems with elegant, user-centered solutions.
                 </p>
                 <p>
-                  Samples of his work can be found in the <Link href='/'>main gallery</Link>, with code examples on{' '}
-                  <a href='https://github.com/michaelzick' target='_blank' rel='noopener noreferrer'>GitHub</a>, and a
-                  full list of qualifications on <a href='https://linkedin.com/in/michaelzick'
-                    target='_blank' rel='noopener noreferrer'>LinkedIn</a>.
+                  Samples of his work can be found in the <TrackedLink href='/' label='main gallery' location='about_modal' section='body'>main gallery</TrackedLink>, with code examples on{' '}
+                  <TrackedLink href='https://github.com/michaelzick' label='GitHub' location='about_modal' section='body'
+                    target='_blank' rel='noopener noreferrer'>GitHub</TrackedLink>, and a
+                  full list of qualifications on <TrackedLink href='https://linkedin.com/in/michaelzick'
+                    label='LinkedIn' location='about_modal' section='body'
+                    target='_blank' rel='noopener noreferrer'>LinkedIn</TrackedLink>.
                 </p>
               </AboutModalCopy>
             </AboutModal>

--- a/src/components/AntisyphonContent.tsx
+++ b/src/components/AntisyphonContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import FsLightbox from 'fslightbox-react';
 
 import {
@@ -32,6 +32,7 @@ import {
 import useAnimatedSections from '../hooks/useAnimatedSections';
 import useHorizontalGallery from '../hooks/useHorizontalGallery';
 import useLightboxController from '../hooks/useLightboxController';
+import { trackEvent } from '../lib/analytics';
 
 type SectionKey = 'case-study' | 'flows';
 
@@ -46,9 +47,9 @@ const AntisyphonContent = () => {
   const { lightboxController: methodLightboxController, openLightbox: openMethodLightbox } = useLightboxController();
   const { lightboxController: flowLightboxController, openLightbox: openFlowLightbox } = useLightboxController();
   const { rowRef, canScrollLeft, canScrollRight, scrollGalleryBy } = useHorizontalGallery(activeTab);
-  const methodImages = METHOD_SECTIONS.flatMap(({ images }) => images);
-  const flowImages = FLOW_BLOCKS.flatMap(({ images }) => images);
-  const caseStudyImages = [...TLDR_ITEMS.map(({ image }) => image), ...HOW_IMAGES];
+  const methodImages = useMemo(() => METHOD_SECTIONS.flatMap(({ images }) => images), []);
+  const flowImages = useMemo(() => FLOW_BLOCKS.flatMap(({ images }) => images), []);
+  const caseStudyImages = useMemo(() => [...TLDR_ITEMS.map(({ image }) => image), ...HOW_IMAGES], []);
 
   const handleTopTabsRef = useCallback((node: HTMLDivElement | null) => {
     setTopTabsEl(node);
@@ -71,8 +72,62 @@ const AntisyphonContent = () => {
   }, [activeTab]);
 
   const togglePersona = useCallback((id: string) => {
-    setOpenPersonaId(current => current === id ? null : id);
+    setOpenPersonaId(current => {
+      const isClosing = current === id;
+      trackEvent(isClosing ? 'modal_close' : 'modal_open', {
+        location: 'antisyphon_personas',
+        modal: 'persona',
+        persona_id: id,
+        page_path: window.location.pathname,
+      });
+      return isClosing ? null : id;
+    });
   }, []);
+
+  const handleGalleryScroll = useCallback((direction: number) => {
+    trackEvent('gallery_scroll', {
+      location: 'antisyphon_case_study_gallery',
+      direction: direction < 0 ? 'left' : 'right',
+      page_path: window.location.pathname,
+    });
+    scrollGalleryBy(direction);
+  }, [scrollGalleryBy]);
+
+  const handleOpenCaseStudyLightbox = useCallback((index: number) => {
+    const image = caseStudyImages[index];
+    trackEvent('lightbox_open', {
+      location: 'antisyphon_case_study',
+      image_index: index,
+      image_alt: image?.alt,
+      image_url: image?.src,
+      page_path: window.location.pathname,
+    });
+    openLightbox(index);
+  }, [caseStudyImages, openLightbox]);
+
+  const handleOpenMethodLightbox = useCallback((index: number) => {
+    const image = methodImages[index];
+    trackEvent('lightbox_open', {
+      location: 'antisyphon_methods',
+      image_index: index,
+      image_alt: image?.alt,
+      image_url: image?.src,
+      page_path: window.location.pathname,
+    });
+    openMethodLightbox(index);
+  }, [methodImages, openMethodLightbox]);
+
+  const handleOpenFlowLightbox = useCallback((index: number) => {
+    const image = flowImages[index];
+    trackEvent('lightbox_open', {
+      location: 'antisyphon_product_screens',
+      image_index: index,
+      image_alt: image?.alt,
+      image_url: image?.src,
+      page_path: window.location.pathname,
+    });
+    openFlowLightbox(index);
+  }, [flowImages, openFlowLightbox]);
 
   return (
     <>
@@ -105,9 +160,9 @@ const AntisyphonContent = () => {
             scrollRowRef={rowRef}
             canScrollLeft={canScrollLeft}
             canScrollRight={canScrollRight}
-            scrollGalleryBy={scrollGalleryBy}
-            openLightbox={openLightbox}
-            openMethodLightbox={openMethodLightbox}
+            scrollGalleryBy={handleGalleryScroll}
+            openLightbox={handleOpenCaseStudyLightbox}
+            openMethodLightbox={handleOpenMethodLightbox}
             openPersonaId={openPersonaId}
             togglePersona={togglePersona}
             topTabsEl={topTabsEl}
@@ -122,7 +177,7 @@ const AntisyphonContent = () => {
             topTabsEl={topTabsEl}
             sections={FLOW_SECTIONS}
             isActive={!isCaseStudyView}
-            openFlowLightbox={openFlowLightbox}
+            openFlowLightbox={handleOpenFlowLightbox}
           />
         )}
       </Wrapper>

--- a/src/components/DemoStokeContent.tsx
+++ b/src/components/DemoStokeContent.tsx
@@ -20,6 +20,7 @@ import StoriesContent from './demostoke/StoriesContent';
 import useAnimatedSections from '../hooks/useAnimatedSections';
 import useHorizontalGallery from '../hooks/useHorizontalGallery';
 import useLightboxController from '../hooks/useLightboxController';
+import { trackEvent } from '../lib/analytics';
 
 type SectionKey = 'case-study' | 'stories';
 
@@ -55,8 +56,38 @@ const DemoStokeContent = () => {
   }, [activeTab]);
 
   const togglePersona = useCallback((id: string) => {
-    setOpenPersonaId(current => current === id ? null : id);
+    setOpenPersonaId(current => {
+      const isClosing = current === id;
+      trackEvent(isClosing ? 'modal_close' : 'modal_open', {
+        location: 'demostoke_personas',
+        modal: 'persona',
+        persona_id: id,
+        page_path: window.location.pathname,
+      });
+      return isClosing ? null : id;
+    });
   }, []);
+
+  const handleGalleryScroll = useCallback((direction: number) => {
+    trackEvent('gallery_scroll', {
+      location: 'demostoke_case_study_gallery',
+      direction: direction < 0 ? 'left' : 'right',
+      page_path: window.location.pathname,
+    });
+    scrollGalleryBy(direction);
+  }, [scrollGalleryBy]);
+
+  const handleOpenLightbox = useCallback((index: number) => {
+    const image = caseStudyImages[index];
+    trackEvent('lightbox_open', {
+      location: 'demostoke_case_study',
+      image_index: index,
+      image_alt: image?.alt,
+      image_url: image?.src,
+      page_path: window.location.pathname,
+    });
+    openLightbox(index);
+  }, [caseStudyImages, openLightbox]);
 
   return (
     <>
@@ -87,8 +118,8 @@ const DemoStokeContent = () => {
             scrollRowRef={rowRef}
             canScrollLeft={canScrollLeft}
             canScrollRight={canScrollRight}
-            scrollGalleryBy={scrollGalleryBy}
-            openLightbox={openLightbox}
+            scrollGalleryBy={handleGalleryScroll}
+            openLightbox={handleOpenLightbox}
             openPersonaId={openPersonaId}
             togglePersona={togglePersona}
             topTabsEl={topTabsEl}

--- a/src/components/DemoStokeTabs.tsx
+++ b/src/components/DemoStokeTabs.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import { CaseStudyTopTabButton, DemoStokeTabsBar } from '../../styles';
+import { trackEvent } from '../lib/analytics';
 
 type TabConfig = {
   key: string;
@@ -29,7 +30,15 @@ const DemoStokeTabs = forwardRef<HTMLDivElement, DemoStokeTabsProps>(({
           tabIndex={activeTab === tab.key ? 0 : -1}
           data-active={activeTab === tab.key ? 'true' : 'false'}
           $isActive={activeTab === tab.key}
-          onClick={() => onTabClick(tab.key)}
+          onClick={() => {
+            trackEvent('case_study_tab_click', {
+              location: 'case_study_top_tabs',
+              tab_key: tab.key,
+              label: tab.label,
+              page_path: window.location.pathname,
+            });
+            onTabClick(tab.key);
+          }}
         >
           {tab.label}
         </CaseStudyTopTabButton>

--- a/src/components/FooterContent.tsx
+++ b/src/components/FooterContent.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
 import { ReactElement } from 'react';
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 import { CASE_STUDIES_LINKS } from './caseStudiesLinks';
 import { PROJECT_LINKS } from './projectLinks';
 import { CONTACT_LINKS } from './contactLinks';
+import TrackedLink from './TrackedLink';
 
 import {
   Footer,
@@ -22,7 +22,9 @@ const FooterContent = (): ReactElement => (
         <FooterColumnLinks>
           {CASE_STUDIES_LINKS.map(({ href, label }) => (
             <li key={href}>
-              <Link href={href}>{label}</Link>
+              <TrackedLink href={href} label={label} location='footer' section='case_studies'>
+                {label}
+              </TrackedLink>
             </li>
           ))}
         </FooterColumnLinks>
@@ -33,7 +35,9 @@ const FooterContent = (): ReactElement => (
         <FooterColumnLinks>
           {PROJECT_LINKS.map(({ href, label }) => (
             <li key={href}>
-              <Link href={href}>{label}</Link>
+              <TrackedLink href={href} label={label} location='footer' section='ux_design'>
+                {label}
+              </TrackedLink>
             </li>
           ))}
         </FooterColumnLinks>
@@ -44,9 +48,16 @@ const FooterContent = (): ReactElement => (
         <FooterColumnLinks>
           {CONTACT_LINKS.map(({ href, label }) => (
             <li key={href}>
-              <a href={href} target="_blank" rel="noopener noreferrer">
+              <TrackedLink
+                href={href}
+                label={label}
+                location='footer'
+                section='links'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
                 {label} <OpenInNewWindowIcon aria-hidden="true" />
-              </a>
+              </TrackedLink>
             </li>
           ))}
         </FooterColumnLinks>

--- a/src/components/LinkBoxContent.tsx
+++ b/src/components/LinkBoxContent.tsx
@@ -1,9 +1,10 @@
-import Link from 'next/link';
 import { useEffect, useRef, useState, type FocusEvent } from 'react';
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 import { CASE_STUDIES_LINKS } from './caseStudiesLinks';
 import { CONTACT_LINKS } from './contactLinks';
 import { PROJECT_LINKS } from './projectLinks';
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
 import {
   LinkBox,
   CaseStudiesDesktopWrapper,
@@ -30,6 +31,13 @@ const LinkBoxContent = () => {
 
   const openCaseStudies = () => {
     clearHoverTimeout();
+    if (!isCaseStudiesOpen) {
+      trackEvent('nav_dropdown_open', {
+        location: 'top_nav',
+        label: 'Case Studies',
+        page_path: window.location.pathname,
+      });
+    }
     setIsCaseStudiesOpen(true);
     setIsProjectsOpen(false);
     setIsContactOpen(false);
@@ -37,6 +45,13 @@ const LinkBoxContent = () => {
 
   const openProjects = () => {
     clearHoverTimeout();
+    if (!isProjectsOpen) {
+      trackEvent('nav_dropdown_open', {
+        location: 'top_nav',
+        label: 'UX Design',
+        page_path: window.location.pathname,
+      });
+    }
     setIsProjectsOpen(true);
     setIsCaseStudiesOpen(false);
     setIsContactOpen(false);
@@ -44,6 +59,13 @@ const LinkBoxContent = () => {
 
   const openContact = () => {
     clearHoverTimeout();
+    if (!isContactOpen) {
+      trackEvent('nav_dropdown_open', {
+        location: 'top_nav',
+        label: 'Links',
+        page_path: window.location.pathname,
+      });
+    }
     setIsContactOpen(true);
     setIsCaseStudiesOpen(false);
     setIsProjectsOpen(false);
@@ -93,7 +115,9 @@ const LinkBoxContent = () => {
 
   return (
     <LinkBox>
-      <Link href='/about'>About</Link>
+      <TrackedLink href='/about' label='About' location='top_nav' section='primary'>
+        About
+      </TrackedLink>
       <CaseStudiesDesktopWrapper
         ref={caseStudiesRef}
         onMouseEnter={openCaseStudies}
@@ -126,10 +150,17 @@ const LinkBoxContent = () => {
           aria-hidden={!isCaseStudiesOpen}>
           {CASE_STUDIES_LINKS.map(({ href, label, icon, iconAlt }) => (
             <li key={href} onClick={handleLinkClick}>
-              <Link href={href} tabIndex={isCaseStudiesOpen ? 0 : -1}>
+              <TrackedLink
+                href={href}
+                label={label}
+                location='top_nav'
+                section='case_studies_dropdown'
+                variant='desktop'
+                tabIndex={isCaseStudiesOpen ? 0 : -1}
+              >
                 {icon ? <img className='case-logo' src={icon} alt={iconAlt || `${label} logo`} /> : null}
                 {label}
-              </Link>
+              </TrackedLink>
             </li>
           ))}
           </CaseStudiesDropdown>
@@ -166,10 +197,17 @@ const LinkBoxContent = () => {
           aria-hidden={!isProjectsOpen}>
           {PROJECT_LINKS.map(({ href, label, icon, iconAlt }) => (
             <li key={href} onClick={handleLinkClick}>
-              <Link href={href} tabIndex={isProjectsOpen ? 0 : -1}>
+              <TrackedLink
+                href={href}
+                label={label}
+                location='top_nav'
+                section='ux_design_dropdown'
+                variant='desktop'
+                tabIndex={isProjectsOpen ? 0 : -1}
+              >
                 {icon ? <img className='case-logo' src={icon} alt={iconAlt || `${label} logo`} /> : null}
                 {label}
-              </Link>
+              </TrackedLink>
             </li>
           ))}
           </CaseStudiesDropdown>
@@ -206,9 +244,18 @@ const LinkBoxContent = () => {
           aria-hidden={!isContactOpen}>
           {CONTACT_LINKS.map(({ href, label }) => (
             <li key={href} onClick={handleLinkClick}>
-              <a href={href} target='_blank' rel='noopener noreferrer' tabIndex={isContactOpen ? 0 : -1}>
+              <TrackedLink
+                href={href}
+                label={label}
+                location='top_nav'
+                section='links_dropdown'
+                variant='desktop'
+                target='_blank'
+                rel='noopener noreferrer'
+                tabIndex={isContactOpen ? 0 : -1}
+              >
                 {label} <OpenInNewWindowIcon aria-hidden='true' />
-              </a>
+              </TrackedLink>
             </li>
           ))}
         </CaseStudiesDropdown>

--- a/src/components/LinkBoxMobileContent.tsx
+++ b/src/components/LinkBoxMobileContent.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { MouseEvent, useState } from 'react';
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 
@@ -11,6 +10,8 @@ import {
 import { CASE_STUDIES_LINKS } from './caseStudiesLinks';
 import { CONTACT_LINKS } from './contactLinks';
 import { PROJECT_LINKS } from './projectLinks';
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
 import {
   LinkBoxMobile,
   CaseStudiesAccordionButton,
@@ -29,18 +30,29 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
   const [isContactOpen, setIsContactOpen] = useState(false);
 
   const handleCloseMenu = () => dispatch(showMobileMenu(false));
+  const trackAccordionOpen = (label: string, expanded: boolean) => {
+    if (expanded) return;
+    trackEvent('nav_dropdown_open', {
+      location: 'mobile_nav',
+      label,
+      page_path: window.location.pathname,
+    });
+  };
 
   return (
     <LinkBoxMobile
       $isAnimating={isAnimating}
       onClick={(event: MouseEvent<HTMLUListElement>) => event.stopPropagation()}>
       <li onClick={handleCloseMenu}>
-        <Link href='/about'>About</Link>
+        <TrackedLink href='/about' label='About' location='mobile_nav' section='primary' variant='mobile'>
+          About
+        </TrackedLink>
       </li>
       <li className='case-studies-accordion'>
         <CaseStudiesAccordionButton
           type='button'
           onClick={() => {
+            trackAccordionOpen('Case Studies', isCaseStudiesOpen);
             setIsCaseStudiesOpen((prevState) => !prevState);
             setIsProjectsOpen(false);
             setIsContactOpen(false);
@@ -56,10 +68,10 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
         <CaseStudiesAccordionList $isOpen={isCaseStudiesOpen}>
           {CASE_STUDIES_LINKS.map(({ href, label, icon, iconAlt }) => (
             <li key={href} onClick={handleCloseMenu}>
-              <Link href={href}>
+              <TrackedLink href={href} label={label} location='mobile_nav' section='case_studies_accordion' variant='mobile'>
                 {icon ? <img className='case-logo' src={icon} alt={iconAlt || `${label} logo`} /> : null}
                 {label}
-              </Link>
+              </TrackedLink>
             </li>
           ))}
         </CaseStudiesAccordionList>
@@ -68,6 +80,7 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
         <CaseStudiesAccordionButton
           type='button'
           onClick={() => {
+            trackAccordionOpen('UX Design', isProjectsOpen);
             setIsProjectsOpen((prevState) => !prevState);
             setIsCaseStudiesOpen(false);
             setIsContactOpen(false);
@@ -83,10 +96,10 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
         <CaseStudiesAccordionList $isOpen={isProjectsOpen}>
           {PROJECT_LINKS.map(({ href, label, icon, iconAlt }) => (
             <li key={href} onClick={handleCloseMenu}>
-              <Link href={href}>
+              <TrackedLink href={href} label={label} location='mobile_nav' section='ux_design_accordion' variant='mobile'>
                 {icon ? <img className='case-logo' src={icon} alt={iconAlt || `${label} logo`} /> : null}
                 {label}
-              </Link>
+              </TrackedLink>
             </li>
           ))}
         </CaseStudiesAccordionList>
@@ -95,6 +108,7 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
         <CaseStudiesAccordionButton
           type='button'
           onClick={() => {
+            trackAccordionOpen('Links', isContactOpen);
             setIsContactOpen((prevState) => !prevState);
             setIsCaseStudiesOpen(false);
             setIsProjectsOpen(false);
@@ -110,9 +124,18 @@ const LinkBoxMobileContent = ({ isAnimating = true }: LinkBoxMobileContentProps)
         <CaseStudiesAccordionList $isOpen={isContactOpen}>
           {CONTACT_LINKS.map(({ href, label }) => (
             <li key={href} onClick={handleCloseMenu}>
-              <a className='external-link' href={href} target='_blank' rel='noopener noreferrer'>
+              <TrackedLink
+                className='external-link'
+                href={href}
+                label={label}
+                location='mobile_nav'
+                section='links_accordion'
+                variant='mobile'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
                 {label} <OpenInNewWindowIcon aria-hidden='true' />
-              </a>
+              </TrackedLink>
             </li>
           ))}
         </CaseStudiesAccordionList>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -34,6 +34,7 @@ import {
   WorksSectionContent
 } from '../../styles';
 import { AnimatedSection } from '../../styles/projectShowcases';
+import { trackEvent } from '../lib/analytics';
 
 type HomeSectionKey = 'case-studies' | 'ux' | 'ui';
 type ActiveSection = HomeSectionKey | null;
@@ -203,6 +204,16 @@ const MainContent = () => {
     const durationMs = animateScrollTo(offsetPosition);
     startManualScroll(durationMs);
   }, [animateScrollTo, startManualScroll]);
+
+  const handleHomeSectionClick = useCallback((section: HomeSectionKey, label: string, location: string) => {
+    trackEvent(label === 'See Case Studies' ? 'cta_click' : 'section_tab_click', {
+      location,
+      label,
+      section,
+      page_path: window.location.pathname,
+    });
+    scrollToHomeSection(section);
+  }, [scrollToHomeSection]);
 
   useEffect(() => {
     return () => {
@@ -521,7 +532,7 @@ const MainContent = () => {
             aria-controls='case-studies'
             tabIndex={activeSection === 'case-studies' ? 0 : -1}
             $isActive={activeSection === 'case-studies'}
-            onClick={() => scrollToHomeSection('case-studies')}
+            onClick={() => handleHomeSectionClick('case-studies', 'Case Studies', 'home_tabs')}
           >
             Case Studies
           </HomeTabButton>
@@ -532,7 +543,7 @@ const MainContent = () => {
             aria-controls='ux-design'
             tabIndex={activeSection === 'ux' ? 0 : -1}
             $isActive={activeSection === 'ux'}
-            onClick={() => scrollToHomeSection('ux')}
+            onClick={() => handleHomeSectionClick('ux', 'UX Design', 'home_tabs')}
           >
             UX Design
           </HomeTabButton>
@@ -543,7 +554,7 @@ const MainContent = () => {
             aria-controls='web-development'
             tabIndex={activeSection === 'ui' ? 0 : -1}
             $isActive={activeSection === 'ui'}
-            onClick={() => scrollToHomeSection('ui')}
+            onClick={() => handleHomeSectionClick('ui', 'Web Dev', 'home_tabs')}
           >
             Web Dev
           </HomeTabButton>
@@ -583,7 +594,7 @@ const MainContent = () => {
                 <button
                   type="button"
                   className="case-studies-cta"
-                  onClick={() => scrollToHomeSection('case-studies')}
+                  onClick={() => handleHomeSectionClick('case-studies', 'See Case Studies', 'home_intro')}
                 >
                   See Case Studies
                 </button>

--- a/src/components/PageAnalytics.tsx
+++ b/src/components/PageAnalytics.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { trackPageView } from '../lib/analytics';
+
+const PageAnalytics = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const trackCurrentPage = (url?: string) => {
+      window.requestAnimationFrame(() => {
+        trackPageView(url);
+      });
+    };
+
+    trackCurrentPage();
+    router.events.on('routeChangeComplete', trackCurrentPage);
+
+    return () => {
+      router.events.off('routeChangeComplete', trackCurrentPage);
+    };
+  }, [router.events]);
+
+  return null;
+};
+
+export default PageAnalytics;

--- a/src/components/ProjectShowcase.tsx
+++ b/src/components/ProjectShowcase.tsx
@@ -31,6 +31,8 @@ import {
   AnimatedSection
 } from '../../styles/projectShowcases';
 import { TopNavContent, FooterContent } from '.';
+import TrackedCtaLink from './TrackedCtaLink';
+import { trackEvent } from '../lib/analytics';
 import {
   useAppSelector,
   useAppDispatch
@@ -143,9 +145,17 @@ const ProjectShowcase = ({
                   <LinkRow>
                     <HeroLabel>Project Link</HeroLabel>
                     <div>
-                      <a href={projectLink.href} target='_blank' rel='noopener noreferrer'>
+                      <TrackedCtaLink
+                        href={projectLink.href}
+                        label={projectLink.label || 'View Project'}
+                        location='project_showcase_hero'
+                        section={title}
+                        eventName='external_project_click'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
                         {projectLink.label || 'View Project'} <OpenInNewWindowIcon aria-hidden="true" />
-                      </a>
+                      </TrackedCtaLink>
                     </div>
                   </LinkRow>
                 </HeroContent>
@@ -171,7 +181,17 @@ const ProjectShowcase = ({
                           type='button'
                           className="image-animate"
                           aria-label={`Open image: ${image.alt}`}
-                          onClick={() => setLightboxState(prev => ({ toggler: !prev.toggler, slide: index + 1 }))}
+                          onClick={() => {
+                            trackEvent('lightbox_open', {
+                              location: 'project_showcase',
+                              project_title: title,
+                              section_title: sectionTitle,
+                              image_alt: image.alt,
+                              image_index: index,
+                              page_path: window.location.pathname,
+                            });
+                            setLightboxState(prev => ({ toggler: !prev.toggler, slide: index + 1 }));
+                          }}
                         >
                           <ShowcaseImage
                             src={image.src}

--- a/src/components/SidebarSectionTabs.tsx
+++ b/src/components/SidebarSectionTabs.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, type CSSProperties } from 'react';
 import { useSize } from '@radix-ui/react-use-size';
+import { trackEvent } from '../lib/analytics';
 
 import {
   SectionTabsWrapper,
@@ -278,7 +279,16 @@ const SidebarSectionTabs = (props: SidebarSectionTabsProps) => {
           type='button'
           $isActive={resolvedActiveSection === id}
           aria-current={resolvedActiveSection === id ? 'true' : undefined}
-          onClick={() => handleTabClick(id)}
+          onClick={() => {
+            trackEvent('section_tab_click', {
+              location: 'sidebar_section_tabs',
+              variant: 'desktop',
+              section: id,
+              label,
+              page_path: window.location.pathname,
+            });
+            handleTabClick(id);
+          }}
         >
           {label}
         </SectionTabButton>
@@ -321,7 +331,16 @@ export const SidebarSectionTabsMobile = (props: SidebarSectionTabsProps) => {
             type='button'
             $isActive={activeSection === id}
             aria-current={activeSection === id ? 'true' : undefined}
-            onClick={() => handleTabClick(id)}
+            onClick={() => {
+              trackEvent('section_tab_click', {
+                location: 'sidebar_section_tabs',
+                variant: 'mobile',
+                section: id,
+                label,
+                page_path: window.location.pathname,
+              });
+              handleTabClick(id);
+            }}
           >
             {label}
           </SectionTabsMobileButton>

--- a/src/components/SiteAnalyticsScripts.tsx
+++ b/src/components/SiteAnalyticsScripts.tsx
@@ -1,0 +1,44 @@
+import Script from 'next/script';
+
+const AMPLITUDE_API_KEY = 'd795dbfcd00a9b445dc1dcdc3a19672a';
+
+const SiteAnalyticsScripts = () => (
+  <>
+    <Script
+      strategy='afterInteractive'
+      src={`https://cdn.amplitude.com/script/${AMPLITUDE_API_KEY}.js`}
+    />
+    <Script id='amplitude-init' strategy='afterInteractive'>
+      {`
+        (function () {
+          var start = Date.now();
+          var maxWaitMs = 8000;
+
+          function tryInit() {
+            if (window.__amplitudeInitialized) return;
+            if (!window.amplitude || !window.amplitude.init) {
+              if (Date.now() - start < maxWaitMs) {
+                setTimeout(tryInit, 100);
+              }
+              return;
+            }
+
+            if (window.sessionReplay && window.sessionReplay.plugin && window.amplitude.add) {
+              window.amplitude.add(window.sessionReplay.plugin({ sampleRate: 1 }));
+            }
+
+            window.amplitude.init('${AMPLITUDE_API_KEY}', {
+              fetchRemoteConfig: true,
+              autocapture: true
+            });
+            window.__amplitudeInitialized = true;
+          }
+
+          tryInit();
+        })();
+      `}
+    </Script>
+  </>
+);
+
+export default SiteAnalyticsScripts;

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -1,9 +1,10 @@
-import Link from 'next/link';
 import { ReactElement, useEffect, useRef } from 'react';
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 
 import { WorksData } from '../types';
 import { Thumb } from '../../styles';
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
 
 type AdditionalThumbProps = {
   index: number,
@@ -191,30 +192,63 @@ const Thumbnail = (props: WorksData & AdditionalThumbProps): ReactElement => {
     };
   }, []);
 
+  const handleThumbClick = () => {
+    trackEvent('project_card_click', {
+      location: 'project_grid',
+      project_group: group,
+      project_title: header,
+      card_index: index,
+      link_url: link || `/${group}`,
+      link_external: Boolean(linkOut),
+      page_path: window.location.pathname,
+    });
+    onThumbClick(index, linkOut);
+  };
+
   return (
-    <Thumb onClick={() => onThumbClick(index)}>
+    <Thumb onClick={handleThumbClick}>
       {imgs && link ?
-        <Link href={link || `/${group}`}
-          target={linkOut ? '_blank' : '_self'} rel={linkOut ? 'noopener noreferrer' : undefined}>
+        <TrackedLink
+          href={link || `/${group}`}
+          label={header}
+          location='project_grid'
+          section='thumbnail_image'
+          target={linkOut ? '_blank' : '_self'}
+          rel={linkOut ? 'noopener noreferrer' : undefined}
+        >
           <div className='thumb-media' ref={containerRef}>
             <img src={thumb} width='240' height='240' alt={group} className='thumb' />
             <canvas ref={canvasRef} className='neon-trail-thumb' aria-hidden='true' />
             <div ref={cursorDotRef} className='cursor-dot thumb-dot' aria-hidden='true' />
           </div>
-        </Link> :
+        </TrackedLink> :
         <div className='thumb-media' ref={containerRef}>
           <img src={thumb} width='240' height='240' alt={group} className='thumb' />
           <canvas ref={canvasRef} className='neon-trail-thumb' aria-hidden='true' />
           <div ref={cursorDotRef} className='cursor-dot thumb-dot' aria-hidden='true' />
         </div>}
 
-      <h3>{link ? <Link href={link || `/${group}`} target={linkOut ? '_blank' : '_self'} rel={linkOut ? 'noopener noreferrer' : undefined}>
-        {header}</Link> : header}
+      <h3>{link ? <TrackedLink
+        href={link || `/${group}`}
+        label={header}
+        location='project_grid'
+        section='thumbnail_title'
+        target={linkOut ? '_blank' : '_self'}
+        rel={linkOut ? 'noopener noreferrer' : undefined}
+      >
+        {header}</TrackedLink> : header}
       </h3>
 
       <p>
-        {link ? <Link href={link || `/${group}`} target={linkOut ? '_blank' : '_self'} rel={linkOut ? 'noopener noreferrer' : undefined}>
-          {desc}</Link> : desc}
+        {link ? <TrackedLink
+          href={link || `/${group}`}
+          label={header}
+          location='project_grid'
+          section='thumbnail_description'
+          target={linkOut ? '_blank' : '_self'}
+          rel={linkOut ? 'noopener noreferrer' : undefined}
+        >
+          {desc}</TrackedLink> : desc}
         {linkOut ? (
           <span className='external-link-icon' aria-hidden='true'>
             <OpenInNewWindowIcon />

--- a/src/components/TopNavContent.tsx
+++ b/src/components/TopNavContent.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import {
   useAppSelector,
   useAppDispatch
@@ -12,6 +10,8 @@ import {
 import { Title, Nav, MenuIcon, ThemeSwitcherWrapper } from '../../styles';
 import { LinkBoxContent, AnimatedMobileMenu, ThemeSwitcher } from '.';
 import { MouseEvent, ReactElement } from 'react';
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
 
 const NavContent = (): ReactElement => {
   const { isMobileMenuShown } = useAppSelector(getMobileMenuState);
@@ -29,10 +29,10 @@ const NavContent = (): ReactElement => {
         isMobileMenuShown={isMobileMenuShown}>
         <Title isMobileMenuShown={isMobileMenuShown}
           onClick={() => dispatch(showMobileMenu(false))}>
-          <Link href='/'>
+          <TrackedLink href='/' label='ZICKONEZERO Creative' location='top_nav' section='brand'>
             <span className='brand-line brand-first'>ZICKONEZERO</span>
             <span className='brand-line brand-second'>Creative</span>
-          </Link>
+          </TrackedLink>
         </Title>
         <ThemeSwitcher />
       </ThemeSwitcherWrapper>
@@ -41,6 +41,11 @@ const NavContent = (): ReactElement => {
 
       <MenuIcon onClick={(event: MouseEvent<HTMLDivElement>) => {
         event.stopPropagation();
+        trackEvent('mobile_menu_toggle', {
+          location: 'top_nav',
+          expanded: !isMobileMenuShown,
+          page_path: window.location.pathname,
+        });
         dispatch(showMobileMenu(!isMobileMenuShown));
       }}
         className={isMobileMenuShown ? 'change' : undefined}>

--- a/src/components/TrackedCtaLink.tsx
+++ b/src/components/TrackedCtaLink.tsx
@@ -1,0 +1,65 @@
+import type { MouseEvent, ReactNode } from 'react';
+
+import { trackEvent } from '../lib/analytics';
+import TrackedLink from './TrackedLink';
+
+type TrackedCtaLinkProps = {
+  href: string;
+  location: string;
+  label: string;
+  eventName?: string;
+  className?: string;
+  target?: string;
+  rel?: string;
+  section?: string;
+  children: ReactNode;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+const resolveEventName = (href: string, label: string, eventName?: string) => {
+  if (eventName) return eventName;
+  if (/project|portfolio|case study/i.test(label)) return 'project_click';
+  if (/contact|book|schedule|request|demo/i.test(label)) return 'cta_click';
+  if (/^https?:\/\//i.test(href)) return 'external_project_click';
+  return 'cta_click';
+};
+
+const TrackedCtaLink = ({
+  href,
+  location,
+  label,
+  eventName,
+  className,
+  target,
+  rel,
+  section = 'cta',
+  children,
+  onClick,
+}: TrackedCtaLinkProps) => {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    trackEvent(resolveEventName(href, label, eventName), {
+      location,
+      label,
+      href,
+      page_path: window.location.pathname,
+    });
+    onClick?.(event);
+  };
+
+  return (
+    <TrackedLink
+      href={href}
+      label={label}
+      location={location}
+      section={section}
+      className={className}
+      target={target}
+      rel={rel}
+      onClick={handleClick}
+    >
+      {children}
+    </TrackedLink>
+  );
+};
+
+export default TrackedCtaLink;

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import type { MouseEvent, ReactNode } from 'react';
+
+import { trackLinkClick } from '../lib/analytics';
+
+type TrackedLinkProps = {
+  href: string;
+  label: string;
+  location: string;
+  section?: string;
+  variant?: 'desktop' | 'mobile';
+  className?: string;
+  target?: string;
+  rel?: string;
+  tabIndex?: number;
+  children: ReactNode;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+const TrackedLink = ({
+  href,
+  label,
+  location,
+  section,
+  variant,
+  className,
+  target,
+  rel,
+  tabIndex,
+  children,
+  onClick,
+}: TrackedLinkProps) => {
+  const isInternal = href.startsWith('/') && !href.startsWith('//');
+  const resolvedRel = target === '_blank' ? (rel ?? 'noopener noreferrer') : rel;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    trackLinkClick({
+      location,
+      label,
+      href,
+      section,
+      variant,
+      pagePath: window.location.pathname,
+    });
+    onClick?.(event);
+  };
+
+  if (isInternal && (!target || target === '_self')) {
+    return (
+      <Link href={href} className={className} tabIndex={tabIndex} onClick={handleClick}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target={target}
+      rel={resolvedRel}
+      className={className}
+      tabIndex={tabIndex}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  );
+};
+
+export default TrackedLink;

--- a/src/components/antisyphon/screens/IntroSection.tsx
+++ b/src/components/antisyphon/screens/IntroSection.tsx
@@ -2,6 +2,7 @@ import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 
 import { PitchDeckLink } from '../../../../styles';
 import { AntisyphonHeroImageWrap } from '../../../../styles/antisyphon';
+import { trackEvent, trackLinkClick } from '../../../lib/analytics';
 import {
   HeroMediaFrame,
   CompactIntroHeaderRow,
@@ -19,7 +20,25 @@ const IntroSection = ({ openFlowLightbox }: IntroSectionProps) => (
       <img className='at-logo' src='/img/squares/at_logo_purple.webp' alt='Antisyphon Training Logo' />
       <div>
         <h2 className='tab-header page-header'>Antisyphon Product Screens</h2>
-        <PitchDeckLink href='https://www.antisyphontraining.com/' target='_blank' rel='noopener noreferrer'>
+        <PitchDeckLink
+          href='https://www.antisyphontraining.com/'
+          target='_blank'
+          rel='noopener noreferrer'
+          onClick={() => {
+            trackLinkClick({
+              location: 'product_screens_intro',
+              label: 'AntisyphonTraining.com',
+              href: 'https://www.antisyphontraining.com/',
+              section: 'Antisyphon Product Screens',
+            });
+            trackEvent('external_project_click', {
+              location: 'product_screens_intro',
+              label: 'AntisyphonTraining.com',
+              href: 'https://www.antisyphontraining.com/',
+              page_path: window.location.pathname,
+            });
+          }}
+        >
           AntisyphonTraining.com <OpenInNewWindowIcon aria-hidden='true' />
         </PitchDeckLink>
       </div>

--- a/src/components/antisyphon/sections/IntroSection.tsx
+++ b/src/components/antisyphon/sections/IntroSection.tsx
@@ -1,4 +1,5 @@
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
+import { trackEvent, trackLinkClick } from '../../../lib/analytics';
 
 import { AnimatedSection, CaseStudyHeroLabel, CaseStudyHeroMediaFrame, HeroContent, HeroGrid, HiddenSectionAnchor, LinkRow, RoleList, SectionNavRevealAnchor, Summary, Title, ShowcaseMediaButton } from '../../../../styles/projectShowcases';
 import { SetAnimatedSectionRef, VisibleSections } from '../../showcaseTypes';
@@ -43,7 +44,25 @@ const IntroSection = ({ setAnimatedSectionRef, visibleSections, openLightbox }: 
           <LinkRow>
             <CaseStudyHeroLabel>Project Link</CaseStudyHeroLabel>
             <div>
-              <a href='https://www.antisyphontraining.com/' target='_blank' rel='noopener noreferrer'>
+              <a
+                href='https://www.antisyphontraining.com/'
+                target='_blank'
+                rel='noopener noreferrer'
+                onClick={() => {
+                  trackLinkClick({
+                    location: 'case_study_hero',
+                    label: 'AntisyphonTraining.com',
+                    href: 'https://www.antisyphontraining.com/',
+                    section: 'Antisyphon UX Case Study',
+                  });
+                  trackEvent('external_project_click', {
+                    location: 'case_study_hero',
+                    label: 'AntisyphonTraining.com',
+                    href: 'https://www.antisyphontraining.com/',
+                    page_path: window.location.pathname,
+                  });
+                }}
+              >
                 AntisyphonTraining.com <OpenInNewWindowIcon aria-hidden='true' />
               </a>
             </div>

--- a/src/components/demostoke/StoriesContent.tsx
+++ b/src/components/demostoke/StoriesContent.tsx
@@ -2,6 +2,7 @@ import SidebarSectionTabs, { SidebarSectionConfig } from '../SidebarSectionTabs'
 import * as UserStories from '../userstories';
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
 import { PitchDeckLink } from '../../../styles';
+import { trackEvent, trackLinkClick } from '../../lib/analytics';
 import {
   AnimatedSection,
   CompactCaseStudyPageInner,
@@ -40,7 +41,25 @@ const StoriesContent = ({
                 <img className='ds-logo' src='/img/squares/demostoke-logo-square.webp' alt='DemoStoke Logo' />
                 <div>
                   <h2 className='tab-header page-header'>DemoStoke User Stories</h2>
-                  <PitchDeckLink href="https://www.demostoke.com/" target='_blank' rel='noopener noreferrer'>
+                  <PitchDeckLink
+                    href="https://www.demostoke.com/"
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    onClick={() => {
+                      trackLinkClick({
+                        location: 'user_stories_intro',
+                        label: 'DemoStoke.com',
+                        href: 'https://www.demostoke.com/',
+                        section: 'DemoStoke User Stories',
+                      });
+                      trackEvent('external_project_click', {
+                        location: 'user_stories_intro',
+                        label: 'DemoStoke.com',
+                        href: 'https://www.demostoke.com/',
+                        page_path: window.location.pathname,
+                      });
+                    }}
+                  >
                     DemoStoke.com <OpenInNewWindowIcon aria-hidden="true" />
                   </PitchDeckLink>
                 </div>

--- a/src/components/demostoke/sections/IntroSection.tsx
+++ b/src/components/demostoke/sections/IntroSection.tsx
@@ -1,4 +1,5 @@
 import { OpenInNewWindowIcon } from '@radix-ui/react-icons';
+import { trackEvent, trackLinkClick } from '../../../lib/analytics';
 
 import {
   AnimatedSection,
@@ -56,7 +57,25 @@ const IntroSection = ({ setAnimatedSectionRef, visibleSections }: IntroSectionPr
           <LinkRow>
             <CaseStudyHeroLabel>Project Link</CaseStudyHeroLabel>
             <div>
-              <a href='https://www.demostoke.com/' target='_blank' rel='noopener noreferrer'>
+              <a
+                href='https://www.demostoke.com/'
+                target='_blank'
+                rel='noopener noreferrer'
+                onClick={() => {
+                  trackLinkClick({
+                    location: 'case_study_hero',
+                    label: 'DemoStoke.com',
+                    href: 'https://www.demostoke.com/',
+                    section: 'DemoStoke UX Case Study',
+                  });
+                  trackEvent('external_project_click', {
+                    location: 'case_study_hero',
+                    label: 'DemoStoke.com',
+                    href: 'https://www.demostoke.com/',
+                    page_path: window.location.pathname,
+                  });
+                }}
+              >
                 DemoStoke.com <OpenInNewWindowIcon aria-hidden='true' />
               </a>
             </div>

--- a/src/components/userstories/HelpsCarousel.tsx
+++ b/src/components/userstories/HelpsCarousel.tsx
@@ -15,6 +15,7 @@ import {
   DemoStokeMiniCardModalClose,
 } from '../../../styles';
 import { DemoStokeSectionSubheading } from '../../../styles/demostoke';
+import { trackEvent } from '../../lib/analytics';
 
 type HelpsItem = {
   title: string;
@@ -60,17 +61,39 @@ const HelpsCarousel = ({ items, title = 'How DemoStoke Helps' }: HelpsCarouselPr
     const el = rowRef.current;
     if (!el) return;
 
+    trackEvent('gallery_scroll', {
+      location: 'user_story_cards',
+      label: title,
+      direction: direction < 0 ? 'left' : 'right',
+      page_path: window.location.pathname,
+    });
     const scrollAmount = Math.max(el.clientWidth * 0.8, 220) * direction;
     el.scrollBy({ left: scrollAmount, behavior: 'smooth' });
   };
 
   const openModal = useCallback((index: number) => {
+    const item = items[index];
+    trackEvent('modal_open', {
+      location: 'user_story_cards',
+      modal: 'how_demostoke_helps',
+      label: item?.title,
+      card_index: index,
+      page_path: window.location.pathname,
+    });
     setActiveIndex(index);
-  }, []);
+  }, [items]);
 
   const closeModal = useCallback(() => {
+    const item = activeIndex !== null ? items[activeIndex] : null;
+    trackEvent('modal_close', {
+      location: 'user_story_cards',
+      modal: 'how_demostoke_helps',
+      label: item?.title,
+      card_index: activeIndex,
+      page_path: window.location.pathname,
+    });
     setActiveIndex(null);
-  }, []);
+  }, [activeIndex, items]);
 
   const handleModalClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
     event.stopPropagation();

--- a/src/components/userstories/IndieShaper.tsx
+++ b/src/components/userstories/IndieShaper.tsx
@@ -16,6 +16,7 @@ import {
 import { AnimatedSection, CaseStudySectionTitle } from '../../../styles/projectShowcases';
 import HelpsCarousel from './HelpsCarousel';
 import { DemoStokeSectionSubheading } from '../../../styles/demostoke';
+import { trackLinkClick } from '../../lib/analytics';
 
 type StoryProps = {
   wrapWithBioBox?: boolean;
@@ -28,7 +29,21 @@ const IndieShaper = ({
   setAnimatedSectionRef,
   visibleSections
 }: StoryProps) => {
-  const DSLink = <WhiteTransitionAnchor href="https://www.demostoke.com/" target='_blank' rel='noopener noreferrer'>DemoStoke</WhiteTransitionAnchor>;
+  const DSLink = (
+    <WhiteTransitionAnchor
+      href="https://www.demostoke.com/"
+      target='_blank'
+      rel='noopener noreferrer'
+      onClick={() => trackLinkClick({
+        location: 'user_story_body',
+        label: 'DemoStoke',
+        href: 'https://www.demostoke.com/',
+        section: 'Independent Surfboard Shaper',
+      })}
+    >
+      DemoStoke
+    </WhiteTransitionAnchor>
+  );
 
   const renderTable = (
     items: { title: string; description: ReactNode; }[],

--- a/src/components/userstories/SmallSkiBikeShop.tsx
+++ b/src/components/userstories/SmallSkiBikeShop.tsx
@@ -16,6 +16,7 @@ import {
 import { AnimatedSection, CaseStudySectionTitle } from '../../../styles/projectShowcases';
 import HelpsCarousel from './HelpsCarousel';
 import { DemoStokeSectionSubheading } from '../../../styles/demostoke';
+import { trackLinkClick } from '../../lib/analytics';
 
 type StoryProps = {
   wrapWithBioBox?: boolean;
@@ -24,7 +25,21 @@ type StoryProps = {
 };
 
 const SmallSkiBikeShop = ({ wrapWithBioBox = true, setAnimatedSectionRef, visibleSections }: StoryProps) => {
-  const DSLink = <WhiteTransitionAnchor href="https://www.demostoke.com/" target='_blank' rel='noopener noreferrer'>DemoStoke</WhiteTransitionAnchor>;
+  const DSLink = (
+    <WhiteTransitionAnchor
+      href="https://www.demostoke.com/"
+      target='_blank'
+      rel='noopener noreferrer'
+      onClick={() => trackLinkClick({
+        location: 'user_story_body',
+        label: 'DemoStoke',
+        href: 'https://www.demostoke.com/',
+        section: 'Small Ski & Bike Shop',
+      })}
+    >
+      DemoStoke
+    </WhiteTransitionAnchor>
+  );
 
   const renderTable = (
     items: { title: string; description: ReactNode; }[],

--- a/src/components/userstories/WeekendWarrior.tsx
+++ b/src/components/userstories/WeekendWarrior.tsx
@@ -16,6 +16,7 @@ import {
 import { AnimatedSection, CaseStudySectionTitle } from '../../../styles/projectShowcases';
 import HelpsCarousel from './HelpsCarousel';
 import { DemoStokeSectionSubheading } from '../../../styles/demostoke';
+import { trackLinkClick } from '../../lib/analytics';
 
 type StoryProps = {
   wrapWithBioBox?: boolean;
@@ -24,7 +25,21 @@ type StoryProps = {
 };
 
 const WeekendWarrior = ({ wrapWithBioBox = true, setAnimatedSectionRef, visibleSections }: StoryProps) => {
-  const DSLink = <WhiteTransitionAnchor href="https://www.demostoke.com/" target='_blank' rel='noopener noreferrer'>DemoStoke</WhiteTransitionAnchor>;
+  const DSLink = (
+    <WhiteTransitionAnchor
+      href="https://www.demostoke.com/"
+      target='_blank'
+      rel='noopener noreferrer'
+      onClick={() => trackLinkClick({
+        location: 'user_story_body',
+        label: 'DemoStoke',
+        href: 'https://www.demostoke.com/',
+        section: 'Weekend Warrior',
+      })}
+    >
+      DemoStoke
+    </WhiteTransitionAnchor>
+  );
 
   const renderTable = (
     items: { title: string; description: ReactNode; }[],

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,88 @@
+type AmplitudeClient = {
+  track?: (name: string, props?: Record<string, unknown>) => void;
+  logEvent?: (name: string, props?: Record<string, unknown>) => void;
+};
+
+type AnalyticsWindow = Window & {
+  amplitude?: AmplitudeClient;
+};
+
+export type AnalyticsEventPayload = Record<string, unknown>;
+
+export type LinkClickPayload = {
+  location: string;
+  label: string;
+  href: string;
+  section?: string;
+  variant?: 'desktop' | 'mobile';
+  pagePath?: string;
+};
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const getAmplitude = (): AmplitudeClient | undefined => {
+  if (!isBrowser()) return undefined;
+  return (window as AnalyticsWindow).amplitude;
+};
+
+const getPagePath = () => {
+  if (!isBrowser()) return undefined;
+  return window.location.pathname;
+};
+
+const sendAmplitudeEvent = (name: string, payload: AnalyticsEventPayload) => {
+  const amplitude = getAmplitude();
+
+  if (amplitude?.track) {
+    amplitude.track(name, payload);
+    return;
+  }
+
+  if (amplitude?.logEvent) {
+    amplitude.logEvent(name, payload);
+  }
+};
+
+export function trackEvent(name: string, payload: AnalyticsEventPayload = {}) {
+  if (!isBrowser()) return;
+
+  sendAmplitudeEvent(name, payload);
+}
+
+export function trackLinkClick({
+  location,
+  label,
+  href,
+  section,
+  variant,
+  pagePath,
+}: LinkClickPayload) {
+  if (!isBrowser()) return;
+
+  const isExternal = /^[a-z][a-z0-9+.-]*:/i.test(href);
+  const payload = {
+    link_location: location,
+    link_text: label,
+    link_url: href,
+    link_external: isExternal,
+    ...(section ? { link_section: section } : {}),
+    ...(variant ? { link_variant: variant } : {}),
+    page_path: pagePath ?? getPagePath(),
+  };
+
+  trackEvent('link_click', payload);
+}
+
+export function trackPageView(url?: string, title?: string) {
+  if (!isBrowser()) return;
+
+  const resolvedUrl = url ?? `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  const parsedUrl = new URL(resolvedUrl, window.location.origin);
+
+  trackEvent('page_view', {
+    page_path: parsedUrl.pathname,
+    page_url: parsedUrl.href,
+    page_title: title ?? document.title,
+    page_referrer: document.referrer || undefined,
+  });
+}


### PR DESCRIPTION
## Summary
- Added Amplitude script initialization to the pages-router app using the requested API key, while keeping the existing GTM setup intact.
- Introduced shared analytics helpers plus page-view tracking so route changes and initial loads are recorded consistently.
- Added tracked link/CTA wrappers and wired semantic events through navigation, footer, homepage cards, showcase pages, tabs, galleries, modals, and outbound project links.
- Expanded coverage with unit and component tests for analytics helpers, tracked links, and representative showcase interactions.

## Testing
- `npm test -- --runInBand` passed.
- `npm run build` passed.
- Verified the updated analytics wiring with focused test coverage for event payloads and click interactions.